### PR TITLE
Incorporated fix from zoo-calrissian-runner to address literal int to…

### DIFF
--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -220,7 +220,21 @@ class ZooInputs:
 
     def get_processing_parameters(self):
         """Returns a list with the input parameters keys"""
-        return {key: value["value"] for key, value in self.inputs.items()}
+        res={}
+        for key, value in self.inputs.items():
+            if "dataType" in value:
+                match value["dataType"]:
+                    case w if w in ["double","float"]:
+                        res[key]=float(value["value"])
+                    case "integer":
+                        res[key]=int(value["value"])
+                    case "boolean":
+                        res[key]=int(value["value"])
+                    case _:
+                        res[key]=value["value"]
+            else:
+                res[key]=value["value"]
+        return res 
 
 
 class ZooOutputs:

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -229,7 +229,7 @@ class ZooInputs:
                     case "integer":
                         res[key]=int(value["value"])
                     case "boolean":
-                        res[key]=int(value["value"])
+                        res[key]=bool(value["value"])
                     case _:
                         res[key]=value["value"]
             else:


### PR DESCRIPTION
## Bugfix to address error when parsing integers for Calrissian execution
This fix ensures that non-string values are correctly parsed to the workflow as the correct types rather than being converted to strings, as this was causing issues when executing workflows requiring integer inputs.
This fix has been taken from the fix to the EOEPCA zoo-calrissian-runner repository, found [here](https://github.com/EOEPCA/zoo-calrissian-runner/compare/main...feature/fix-literaldata-preservation).