### PR TITLE
Feature/eodhp 654 expose workflow as a user service

### DIFF
--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -290,7 +290,7 @@ class ZooCalrissianRunner:
         self.outputs = ZooOutputs(outputs)
         self.cwl = Workflow(cwl, self.zoo_conf.workflow_id)
         self.token = inputs["user_token"]["value"]
-        self.calling_namespace = inputs["calling_namespace"]["value"]
+        self.calling_workspace = inputs["calling_workspace"]["value"]
 
         self.handler = execution_handler
 
@@ -422,7 +422,7 @@ class ZooCalrissianRunner:
             volume_size=self.get_volume_size(),
             service_account=self.zoo_conf.conf.get("eodhp", {}).get("serviceAccountName", "default"),
             image_pull_secrets=secret_config,
-            calling_namespace=self.calling_namespace,
+            calling_workspace=self.calling_workspace,
         )
         session.initialise()
         self.update_status(progress=15, message="processing environment created, preparing execution")
@@ -475,7 +475,7 @@ class ZooCalrissianRunner:
             no_read_only=True,
             tool_logs=True,
             token = self.token,
-            calling_namespace=self.calling_namespace,
+            calling_workspace=self.calling_workspace,
         )
 
         self.update_status(progress=23, message="execution submitted")

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -291,6 +291,7 @@ class ZooCalrissianRunner:
         self.cwl = Workflow(cwl, self.zoo_conf.workflow_id)
         self.token = inputs["user_token"]["value"]
         self.calling_workspace = inputs["calling_workspace"]["value"]
+        self.executing_workspace = inputs["executing_workspace"]["value"]
 
         self.handler = execution_handler
 
@@ -423,6 +424,7 @@ class ZooCalrissianRunner:
             service_account=self.zoo_conf.conf.get("eodhp", {}).get("serviceAccountName", "default"),
             image_pull_secrets=secret_config,
             calling_workspace=self.calling_workspace,
+            executing_workspace=self.executing_workspace,
         )
         session.initialise()
         self.update_status(progress=15, message="processing environment created, preparing execution")
@@ -476,6 +478,7 @@ class ZooCalrissianRunner:
             tool_logs=True,
             token = self.token,
             calling_workspace=self.calling_workspace,
+            executing_workspace=self.executing_workspace,
         )
 
         self.update_status(progress=23, message="execution submitted")

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -292,6 +292,7 @@ class ZooCalrissianRunner:
         self.token = inputs["user_token"]["value"]
         self.calling_workspace = inputs["calling_workspace"]["value"]
         self.executing_workspace = inputs["executing_workspace"]["value"]
+        self.job_id = conf["lenv"]["usid"]
 
         self.handler = execution_handler
 
@@ -425,6 +426,7 @@ class ZooCalrissianRunner:
             image_pull_secrets=secret_config,
             calling_workspace=self.calling_workspace,
             executing_workspace=self.executing_workspace,
+            job_id=self.job_id,
         )
         session.initialise()
         self.update_status(progress=15, message="processing environment created, preparing execution")
@@ -479,6 +481,7 @@ class ZooCalrissianRunner:
             token = self.token,
             calling_workspace=self.calling_workspace,
             executing_workspace=self.executing_workspace,
+            job_id=self.job_id,
         )
 
         self.update_status(progress=23, message="execution submitted")

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -289,6 +289,7 @@ class ZooCalrissianRunner:
         self.inputs = ZooInputs(inputs)
         self.outputs = ZooOutputs(outputs)
         self.cwl = Workflow(cwl, self.zoo_conf.workflow_id)
+        self.token = inputs["user_token"]["value"]
 
         self.handler = execution_handler
 
@@ -471,6 +472,7 @@ class ZooCalrissianRunner:
             debug=True,
             no_read_only=True,
             tool_logs=True,
+            token = self.token
         )
 
         self.update_status(progress=23, message="execution submitted")

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -290,6 +290,7 @@ class ZooCalrissianRunner:
         self.outputs = ZooOutputs(outputs)
         self.cwl = Workflow(cwl, self.zoo_conf.workflow_id)
         self.token = inputs["user_token"]["value"]
+        self.calling_workspace = inputs["calling_workspace"]["value"]
 
         self.handler = execution_handler
 
@@ -421,6 +422,7 @@ class ZooCalrissianRunner:
             volume_size=self.get_volume_size(),
             service_account=self.zoo_conf.conf.get("eodhp", {}).get("serviceAccountName", "default"),
             image_pull_secrets=secret_config,
+            calling_workspace=self.calling_workspace if self.calling_workspace != self.excuting_workspace else None,
         )
         session.initialise()
         self.update_status(progress=15, message="processing environment created, preparing execution")

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -290,7 +290,7 @@ class ZooCalrissianRunner:
         self.outputs = ZooOutputs(outputs)
         self.cwl = Workflow(cwl, self.zoo_conf.workflow_id)
         self.token = inputs["user_token"]["value"]
-        self.calling_workspace = inputs["calling_workspace"]["value"]
+        self.calling_namespace = inputs["calling_namespace"]["value"]
 
         self.handler = execution_handler
 
@@ -422,7 +422,7 @@ class ZooCalrissianRunner:
             volume_size=self.get_volume_size(),
             service_account=self.zoo_conf.conf.get("eodhp", {}).get("serviceAccountName", "default"),
             image_pull_secrets=secret_config,
-            calling_workspace=self.calling_workspace if self.calling_workspace != self.excuting_workspace else None,
+            calling_namespace=self.calling_namespace,
         )
         session.initialise()
         self.update_status(progress=15, message="processing environment created, preparing execution")
@@ -474,7 +474,8 @@ class ZooCalrissianRunner:
             debug=True,
             no_read_only=True,
             tool_logs=True,
-            token = self.token
+            token = self.token,
+            calling_namespace=self.calling_namespace,
         )
 
         self.update_status(progress=23, message="execution submitted")


### PR DESCRIPTION
## Pass through additional inputs
- PyCalrissian now needs additional inputs to handle user-services (see [PR](https://github.com/UKEODHP/pycalrissian/pull/3))
- These inputs are passed directly through to the two function calls
  - `calling_workspace` - used to determine if this workflow is a user-service
  - `token` - used to authenticate against AWS IAM Role